### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 An MCP server for obtaining text differences between two strings.
 This server leverages Python's standard library `difflib` to efficiently generate and provide differences between two texts in Unified diff format, making it ideal for text comparison and version control purposes.
 
+<a href="https://glama.ai/mcp/servers/qbwsx2g4vd"><img width="380" height="200" src="https://glama.ai/mcp/servers/qbwsx2g4vd/badge" alt="Server Diff Python MCP server" /></a>
+
 ## Features
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Diff Python](https://glama.ai/mcp/servers/qbwsx2g4vd) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/qbwsx2g4vd"><img width="380" height="200" src="https://glama.ai/mcp/servers/qbwsx2g4vd/badge" alt="Server Diff Python MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.